### PR TITLE
Upgrades to Launch4j 3.50

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <name>Maven Launch4j Plugin</name>
     <description>This plugin creates Windows executables from Java jar files using the Launch4j utility.</description>
-    <url>http://9stmaryrd.com/tools/launch4j-maven-plugin/</url>
+    <url>https://orphan.software/</url>
 
     <properties>
         <launch4j.version>3.50</launch4j.version>
@@ -36,14 +36,16 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License</name>
-            <url>http://www.gnu.org/licenses/gpl.txt</url>
+            <name>Apache 2.0 License</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0</url>
             <distribution>repo</distribution>
         </license>
     </licenses>
 
     <scm>
-        <developerConnection>scm:git:git@github.com:lukaszlenart/launch4j-maven-plugin.git</developerConnection>
+        <connection>scm:git:git@github.com:orphan-oss/launch4j-maven-plugin.git</connection>
+        <url>git@github.com:orphan-oss/launch4j-maven-plugin.git</url>
+        <developerConnection>scm:git:git@github.com:orphan-oss/launch4j-maven-plugin.git</developerConnection>
         <tag>HEAD</tag>
     </scm>
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
     <groupId>com.akathist.maven.plugins.launch4j</groupId>
     <artifactId>launch4j-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
-    <version>2.1.4-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <name>Maven Launch4j Plugin</name>
     <description>This plugin creates Windows executables from Java jar files using the Launch4j utility.</description>
     <url>http://9stmaryrd.com/tools/launch4j-maven-plugin/</url>
 
     <properties>
-        <launch4j.version>3.14</launch4j.version>
+        <launch4j.version>3.50</launch4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
@@ -68,21 +68,25 @@
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-plugin-api</artifactId>
             <version>3.8.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-model</artifactId>
             <version>3.8.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-artifact</artifactId>
             <version>3.8.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
             <artifactId>maven-core</artifactId>
             <version>3.8.6</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
@@ -99,6 +103,7 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,25 @@
                     <artifactId>abeille</artifactId>
                     <groupId>net.java.abeille</groupId>
                 </exclusion>
+                <exclusion>
+                    <groupId>com.thoughtworks.xstream</groupId>
+                    <artifactId>xstream</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.ant</groupId>
+                    <artifactId>ant</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.ant</groupId>
+            <artifactId>ant</artifactId>
+            <version>1.10.12</version>
+        </dependency>
+        <dependency>
+            <groupId>com.thoughtworks.xstream</groupId>
+            <artifactId>xstream</artifactId>
+            <version>1.4.19</version>
         </dependency>
         <dependency>
             <groupId>org.apache.maven</groupId>
@@ -103,6 +121,18 @@
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.13.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-testing</groupId>
+            <artifactId>maven-plugin-testing-harness</artifactId>
+            <version>3.3.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-compat</artifactId>
+            <version>3.8.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Jre.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Jre.java
@@ -204,7 +204,7 @@ public class Jre {
 
     public void deprecationWarning(Log log) {
         if (this.bundledJreAsFallback != null) {
-            log.warn("<bundledJreAsFallback/> has been removed! It has not effect!");
+            log.warn("<bundledJreAsFallback/> has been removed! It has no effect!");
         }
         if (this.bundledJre64Bit != null) {
             log.warn("<bundledJre64Bit/> is deprecated, use <requires64Bit/> instead!");

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -423,6 +423,7 @@ public class Launch4jMojo extends AbstractMojo {
                 c.setClassPath(classPath.toL4j(dependencies));
             }
             if (jre != null) {
+                jre.deprecationWarning(getLog());
                 c.setJre(jre.toL4j());
             }
             if (singleInstance != null) {
@@ -435,6 +436,9 @@ public class Launch4jMojo extends AbstractMojo {
                 c.setVersionInfo(versionInfo.toL4j());
             }
             if (messages != null) {
+                if (messages.bundledJreErr != null) {
+                    getLog().warn("<bundledJreErr/> is deprecated, use <jreNotFoundErr/> instead!");
+                }
                 c.setMessages(messages.toL4j());
             }
             ConfigPersister.getInstance().setAntConfig(c, getBaseDir());
@@ -708,7 +712,8 @@ public class Launch4jMojo extends AbstractMojo {
             log.debug("jre.path = " + c.getJre().getPath());
             log.debug("jre.minVersion = " + c.getJre().getMinVersion());
             log.debug("jre.maxVersion = " + c.getJre().getMaxVersion());
-            log.debug("jre.jdkPreference = " + c.getJre().getJdkPreference());
+            log.debug("jre.requiresJdk = " + c.getJre().getRequiresJdk());
+            log.debug("jre.requires64Bit = " + c.getJre().getRequires64Bit());
             log.debug("jre.initialHeapSize = " + c.getJre().getInitialHeapSize());
             log.debug("jre.initialHeapPercent = " + c.getJre().getInitialHeapPercent());
             log.debug("jre.maxHeapSize = " + c.getJre().getMaxHeapSize());
@@ -755,7 +760,7 @@ public class Launch4jMojo extends AbstractMojo {
         }
         if (c.getMessages() != null) {
             log.debug("messages.startupErr = " + c.getMessages().getStartupErr());
-            log.debug("messages.bundledJreErr = " + c.getMessages().getBundledJreErr());
+            log.debug("messages.jreNotFoundErr = " + c.getMessages().getJreNotFoundErr());
             log.debug("messages.jreVersionErr = " + c.getMessages().getJreVersionErr());
             log.debug("messages.launcherErr = " + c.getMessages().getLauncherErr());
             log.debug("messages.instanceAlreadyExistsMsg = " + c.getMessages().getInstanceAlreadyExistsMsg());

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -262,7 +262,7 @@ public class Launch4jMojo extends AbstractMojo {
      * Details about the classpath your application should have.
      * This is required if you are not wrapping a jar.
      */
-    @Parameter
+    @Parameter()
     private ClassPath classPath;
 
     /**
@@ -809,4 +809,37 @@ public class Launch4jMojo extends AbstractMojo {
         return skip || System.getProperty("skipLaunch4j") != null;
     }
 
+    @Override
+    public String toString() {
+        return "Launch4jMojo{" +
+                "headerType='" + headerType + '\'' +
+                ", infile=" + infile +
+                ", outfile=" + outfile +
+                ", jar='" + jar + '\'' +
+                ", dontWrapJar=" + dontWrapJar +
+                ", errTitle='" + errTitle + '\'' +
+                ", downloadUrl='" + downloadUrl + '\'' +
+                ", supportUrl='" + supportUrl + '\'' +
+                ", cmdLine='" + cmdLine + '\'' +
+                ", chdir='" + chdir + '\'' +
+                ", priority='" + priority + '\'' +
+                ", stayAlive=" + stayAlive +
+                ", restartOnCrash=" + restartOnCrash +
+                ", icon=" + icon +
+                ", objs=" + objs +
+                ", libs=" + libs +
+                ", vars=" + vars +
+                ", jre=" + jre +
+                ", classPath=" + classPath +
+                ", singleInstance=" + singleInstance +
+                ", splash=" + splash +
+                ", versionInfo=" + versionInfo +
+                ", messages=" + messages +
+                ", manifest=" + manifest +
+                ", saveConfig=" + saveConfig +
+                ", configOutfile=" + configOutfile +
+                ", parallelExecution=" + parallelExecution +
+                ", skip=" + skip +
+                '}';
+    }
 }

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Messages.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Messages.java
@@ -28,6 +28,7 @@ public class Messages {
 
     String startupErr;
 
+    @Deprecated
     String bundledJreErr;
 
     String jreVersionErr;
@@ -36,16 +37,19 @@ public class Messages {
 
     String instanceAlreadyExistsMsg;
 
+    String jreNotFoundErr;
+
 
     Msg toL4j() {
         Msg ret = new Msg();
 
         ret.setStartupErr(startupErr);
-        ret.setBundledJreErr(bundledJreErr);
         ret.setJreVersionErr(jreVersionErr);
         ret.setLauncherErr(launcherErr);
         ret.setInstanceAlreadyExistsMsg(instanceAlreadyExistsMsg);
 
+        /* since Launch4j 3.50 */
+        ret.setJreNotFoundErr(jreNotFoundErr);
         return ret;
     }
 

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Messages.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Messages.java
@@ -19,26 +19,31 @@
 package com.akathist.maven.plugins.launch4j;
 
 import net.sf.launch4j.config.Msg;
-
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Details about messages you can pass.
  */
 public class Messages {
 
+    @Parameter
     String startupErr;
 
+    @Parameter
     @Deprecated
     String bundledJreErr;
 
+    @Parameter
     String jreVersionErr;
 
+    @Parameter
     String launcherErr;
 
+    @Parameter
     String instanceAlreadyExistsMsg;
 
+    @Parameter
     String jreNotFoundErr;
-
 
     Msg toL4j() {
         Msg ret = new Msg();
@@ -53,4 +58,14 @@ public class Messages {
         return ret;
     }
 
+    @Override
+    public String toString() {
+        return "Messages{" +
+                "startupErr='" + startupErr + '\'' +
+                ", jreVersionErr='" + jreVersionErr + '\'' +
+                ", launcherErr='" + launcherErr + '\'' +
+                ", instanceAlreadyExistsMsg='" + instanceAlreadyExistsMsg + '\'' +
+                ", jreNotFoundErr='" + jreNotFoundErr + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/akathist/maven/plugins/launch4j/SingleInstance.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/SingleInstance.java
@@ -18,14 +18,17 @@
  */
 package com.akathist.maven.plugins.launch4j;
 
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Details about running your application as a single instance.
  */
 public class SingleInstance {
 
+    @Parameter
     String mutexName;
 
+    @Parameter
     String windowTitle;
 
     net.sf.launch4j.config.SingleInstance toL4j() {

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Splash.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Splash.java
@@ -27,6 +27,7 @@ public class Splash {
     /**
      * The path (relative to the executable when distributed) to the splash page image.
      */
+    @Parameter
     File file;
 
     /**
@@ -61,4 +62,13 @@ public class Splash {
         return ret;
     }
 
+    @Override
+    public String toString() {
+        return "Splash{" +
+                "file=" + file +
+                ", waitForWindow=" + waitForWindow +
+                ", timeout=" + timeout +
+                ", timeoutErr=" + timeoutErr +
+                '}';
+    }
 }

--- a/src/main/java/com/akathist/maven/plugins/launch4j/VersionInfo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/VersionInfo.java
@@ -19,6 +19,7 @@
 package com.akathist.maven.plugins.launch4j;
 
 import net.sf.launch4j.config.LanguageID;
+import org.apache.maven.plugins.annotations.Parameter;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -28,7 +29,7 @@ import java.util.Map;
  */
 public class VersionInfo {
 
-    private static Map<String, LanguageID> LANGUAGE_TO_LANGUAGE_ID;
+    private static final Map<String, LanguageID> LANGUAGE_TO_LANGUAGE_ID;
 
     static {
         LANGUAGE_TO_LANGUAGE_ID = new HashMap<>();
@@ -40,61 +41,73 @@ public class VersionInfo {
     /**
      * Version number in x.x.x.x format.
      */
+    @Parameter
     String fileVersion;
 
     /**
      * Free-form version number, like "1.20.RC1."
      */
+    @Parameter
     String txtFileVersion;
 
     /**
      * File description shown to the user.
      */
+    @Parameter
     String fileDescription;
 
     /**
      * Legal copyright.
      */
+    @Parameter
     String copyright;
 
     /**
      * Version number in x.x.x.x format.
      */
+    @Parameter
     String productVersion;
 
     /**
      * Free-form version number, like "1.20.RC1."
      */
+    @Parameter
     String txtProductVersion;
 
     /**
      * The product name.
      */
+    @Parameter
     String productName;
 
     /**
      * The company name.
      */
+    @Parameter
     String companyName;
 
     /**
      * The internal name. For instance, you could use the filename without extension or the module name.
      */
+    @Parameter
     String internalName;
 
     /**
      * The original filename without path. Setting this lets you determine whether a user has renamed the file.
      */
+    @Parameter
     String originalFilename;
 
     /**
      * Language to be used during installation, default ENGLISH_US
      */
+    @Parameter
     String language = LanguageID.ENGLISH_US.name();
 
     /**
      * Trademarks of author
      */
+    @Parameter
     String trademarks;
 
     net.sf.launch4j.config.VersionInfo toL4j() {

--- a/src/test/java/com/akathist/maven/plugins/launch4j/Launch4jMojoTest.java
+++ b/src/test/java/com/akathist/maven/plugins/launch4j/Launch4jMojoTest.java
@@ -1,0 +1,84 @@
+package com.akathist.maven.plugins.launch4j;
+
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+import java.io.File;
+
+public class Launch4jMojoTest extends AbstractMojoTestCase {
+
+    public void testMojoGoal() throws Exception {
+        File testPom = new File(getBasedir(), "src/test/resources/unit/launch4j-default/launch4j-default-plugin-config.xml");
+
+        Launch4jMojo mojo = (Launch4jMojo) lookupMojo("launch4j", testPom);
+
+        assertNotNull(mojo);
+
+        assertEquals("Launch4jMojo{" +
+                "headerType='gui', " +
+                "infile=null, " +
+                "outfile=${project.build.directory}/app.exe, " +
+                "jar='${project.build.directory}/${project.artifactId}-${project.version}.jar', " +
+                "dontWrapJar=false, " +
+                "errTitle='null', " +
+                "downloadUrl='https://java.com/download', " +
+                "supportUrl='null', " +
+                "cmdLine='null', " +
+                "chdir='null', " +
+                "priority='null', " +
+                "stayAlive=false, " +
+                "restartOnCrash=false, " +
+                "icon=null, " +
+                "objs=null, " +
+                "libs=null, " +
+                "vars=null, " +
+                "jre=Jre{" +
+                "path='%JAVA_HOME%;%PATH%', " +
+                "requires64Bit=false, " +
+                "minVersion='1.8', " +
+                "maxVersion='null', " +
+                "requiresJdk=true," +
+                " initialHeapSize=0, " +
+                "initialHeapPercent=0, " +
+                "maxHeapSize=0, " +
+                "maxHeapPercent=0, " +
+                "opts=[-Dname=Lukasz]" +
+                "}, " +
+                "classPath=ClassPath{" +
+                "mainClass='pl.org.lenart.launch4j.App', " +
+                "addDependencies=true, " +
+                "jarLocation='null', " +
+                "preCp='anything', " +
+                "postCp='null'" +
+                "}, " +
+                "singleInstance=null, " +
+                "splash=null, " +
+                "versionInfo=VersionInfo{" +
+                "fileVersion='1.0.0.0', " +
+                "txtFileVersion='${project.version}', " +
+                "fileDescription='Launch4j Demo App', " +
+                "copyright='Lukasz Lenart', " +
+                "productVersion='1.0.0.0', " +
+                "txtProductVersion='1.0.0.0', " +
+                "productName='App', " +
+                "companyName='Lukasz Lenart', " +
+                "internalName='app', " +
+                "originalFilename='app.exe', " +
+                "language='ENGLISH_US', " +
+                "trademarks='Luk ™'" +
+                "}, " +
+                "messages=Messages{" +
+                "startupErr='null', " +
+                "jreVersionErr='null', " +
+                "launcherErr='null', " +
+                "instanceAlreadyExistsMsg='null', " +
+                "jreNotFoundErr='null'" +
+                "}, " +
+                "manifest=null, " +
+                "saveConfig=false, " +
+                "configOutfile=null, " +
+                "parallelExecution=false, " +
+                "skip=false" +
+                "}", mojo.toString());
+    }
+
+}

--- a/src/test/resources/unit/launch4j-default/launch4j-default-plugin-config.xml
+++ b/src/test/resources/unit/launch4j-default/launch4j-default-plugin-config.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.akathist.maven.plugins.launch4j.unit</groupId>
+    <artifactId>launch4j-default</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>launch4j-default</name>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.akathist.maven.plugins.launch4j</groupId>
+                <artifactId>launch4j-maven-plugin</artifactId>
+                <configuration>
+                    <headerType>gui</headerType>
+                    <jar>${project.build.directory}/${project.artifactId}-${project.version}.jar</jar>
+                    <outfile>${project.build.directory}/app.exe</outfile>
+                    <downloadUrl>https://java.com/download</downloadUrl>
+                    <classPath>
+                        <mainClass>pl.org.lenart.launch4j.App</mainClass>
+                        <preCp>anything</preCp>
+                    </classPath>
+                    <jre>
+                        <path>%JAVA_HOME%;%PATH%</path>
+                        <minVersion>1.8</minVersion>
+                        <bundledJreAsFallback>true</bundledJreAsFallback>
+                        <jdkPreference>preferJre</jdkPreference>
+                        <requiresJdk>true</requiresJdk>
+                        <bundledJre64Bit>true</bundledJre64Bit>
+                        <runtimeBits>32</runtimeBits>
+                        <opts>
+                            <opt>-Dname=Lukasz</opt>
+                        </opts>
+                    </jre>
+                    <messages>
+                        <bundledJreErr>Test bundledJreErr</bundledJreErr>
+                    </messages>
+                    <versionInfo>
+                        <fileVersion>1.0.0.0</fileVersion>
+                        <txtFileVersion>${project.version}</txtFileVersion>
+                        <fileDescription>Launch4j Demo App</fileDescription>
+                        <copyright>Lukasz Lenart</copyright>
+                        <productVersion>1.0.0.0</productVersion>
+                        <txtProductVersion>1.0.0.0</txtProductVersion>
+                        <productName>App</productName>
+                        <companyName>Lukasz Lenart</companyName>
+                        <internalName>app</internalName>
+                        <originalFilename>app.exe</originalFilename>
+                        <trademarks>Luk ™</trademarks>
+                    </versionInfo>
+                </configuration>
+            </plugin>
+        </plugins>
+
+    </build>
+
+</project>


### PR DESCRIPTION
Please see the [docs](https://launch4j.sourceforge.net/docs.html) for changes of the configuration options:

- Removed `<bundledJreAsFallback>`, path search is always first and registry search second in order to improve compatibility with modern runtimes.
- Replaced `<bundledJre64Bit>` and `<runtimeBits>` with `<requires64Bit>` which works during path and registry search.
- Replaced `<jdkPreference>` with `<requiresJdk>` which works during path and registry search.
- Replaced `<bundledJreErr>` with `<jreNotFoundErr>`.
- `<minVersion>` and `<maxVersion>` are now used during path and registry search, previously they were only checked during registry search.

The plugin will show warnings when these options are still used:
```
[WARNING] <bundledJreAsFallback/> has been removed! It has no effect!
[WARNING] <bundledJre64Bit/> is deprecated, use <requires64Bit/> instead!
[WARNING] <runtimeBits/> is deprecated, use <requires64Bit/> instead!
[WARNING] <jdkPreference/> is deprecated, use <requiresJdk/> instead!
[WARNING] <bundledJreErr/> is deprecated, use <jreNotFoundErr/> instead!
```

Closes #199