### PR TITLE
Log warnings instead of throwing exceptions for missing params while filling out the VersionInfo defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ The full list of all the parameters is available [here](src/main/resources/MOJO.
 
 # Version Notes
 
+## Version notes 2.3.1 - 2023-01-16
+- logs only warnings instead of throwing exception, when cannot fulfill default values for `<VersionInfo>`
+  (no configuration data required by the formula), see Issue [#213](../../issues/213) and PR [#216](../../pull/216)
+
 ## Version notes 2.3.0 - 2023-01-06
 - provides default values for plugin configuration, especially for `<VersionInfo>`, see Issue [#98](../../issues/98)
 - adds a `disableVersionInfoDefaults` parameter to be able to disable provided defaults, see PR [#205](../../pull/205)

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -351,6 +351,7 @@ public class Launch4jMojo extends AbstractMojo {
                 if(versionInfo == null) {
                     versionInfo = new VersionInfo();
                 }
+                versionInfo.setLog(getLog());
                 versionInfo.tryFillOutByDefaults(project, outfile);
             } catch (RuntimeException exception) {
                 throw new MojoExecutionException("Cannot fill out VersionInfo by defaults", exception);

--- a/src/main/java/com/akathist/maven/plugins/launch4j/generators/CopyrightGenerator.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/generators/CopyrightGenerator.java
@@ -1,7 +1,6 @@
 package com.akathist.maven.plugins.launch4j.generators;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.maven.model.Organization;
 
 import java.time.LocalDate;
 
@@ -12,13 +11,13 @@ public class CopyrightGenerator {
     /**
      * Parameters should be taken from MavenProject properties:
      * @param projectInceptionYear as ${project.inceptionYear}
-     * @param projectOrganization as ${project.organization}
+     * @param projectOrganizationName as ${project.organization.name}
      * @return a string representing copyrights
      */
-    public static String generate(String projectInceptionYear, Organization projectOrganization) {
+    public static String generate(String projectInceptionYear, String projectOrganizationName) {
         String inceptionYear = generateInceptionYear(projectInceptionYear);
         int buildYear = LocalDate.now().getYear();
-        String organizationName = generateOrganizationName(projectOrganization);
+        String organizationName = generateOrganizationName(projectOrganizationName);
 
         return String.format("Copyright © %s%d%s. All rights reserved.", inceptionYear, buildYear, organizationName);
     }
@@ -31,9 +30,9 @@ public class CopyrightGenerator {
         return "";
     }
 
-    private static String generateOrganizationName(Organization projectOrganization) {
-        if(projectOrganization != null && StringUtils.isNotBlank(projectOrganization.getName())) {
-            return " " + projectOrganization.getName();
+    private static String generateOrganizationName(String projectOrganizationName) {
+        if(StringUtils.isNotBlank(projectOrganizationName)) {
+            return " " + projectOrganizationName;
         }
 
         return "";

--- a/src/test/java/com/akathist/maven/plugins/launch4j/VersionInfoTest.java
+++ b/src/test/java/com/akathist/maven/plugins/launch4j/VersionInfoTest.java
@@ -12,6 +12,7 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
 
@@ -335,6 +336,8 @@ public class VersionInfoTest {
     @Test
     public void shouldFillOut_ByDummyValues_When_OriginalValues_Empty_And_ProjectParams_Empty() {
         // given
+        final String buildYear = String.valueOf(LocalDate.now().getYear());
+
         VersionInfo emptyValuesVersionInfo = new VersionInfo();
         emptyValuesVersionInfo.setLog(log);
 
@@ -345,7 +348,7 @@ public class VersionInfoTest {
         assertEquals("1.0.0.0", emptyValuesVersionInfo.fileVersion);
         assertEquals("1.0.0", emptyValuesVersionInfo.txtFileVersion);
         assertEquals("A Java project.", emptyValuesVersionInfo.fileDescription);
-        assertEquals("Copyright © 2020-2023 Default organization. All rights reserved.", emptyValuesVersionInfo.copyright);
+        assertEquals("Copyright © 2020-" + buildYear + " Default organization. All rights reserved.", emptyValuesVersionInfo.copyright);
         assertEquals("1.0.0.0", emptyValuesVersionInfo.productVersion);
         assertEquals("1.0.0", emptyValuesVersionInfo.txtProductVersion);
         assertEquals("Java Project", emptyValuesVersionInfo.productName);

--- a/src/test/java/com/akathist/maven/plugins/launch4j/VersionInfoTest.java
+++ b/src/test/java/com/akathist/maven/plugins/launch4j/VersionInfoTest.java
@@ -2,17 +2,22 @@ package com.akathist.maven.plugins.launch4j;
 
 import net.sf.launch4j.config.LanguageID;
 import org.apache.maven.model.Organization;
+import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.project.MavenProject;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.Assert.*;
-import static org.mockito.Mockito.doReturn;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class VersionInfoTest {
@@ -37,6 +42,8 @@ public class VersionInfoTest {
     MavenProject project;
     @Mock
     File outfile;
+    @Mock
+    Log log;
 
     // Subject
     private VersionInfo versionInfo;
@@ -46,7 +53,8 @@ public class VersionInfoTest {
         versionInfo = new VersionInfo(fileVersion, txtFileVersion, fileDescription,
                 copyright, productVersion, txtProductVersion,
                 productName, companyName, internalName,
-                originalFilename, language, trademarks);
+                originalFilename, language, trademarks,
+                log);
     }
 
     @Test
@@ -173,20 +181,6 @@ public class VersionInfoTest {
     }
 
     @Test
-    public void should_Not_FillOutByDefaults_From_MavenProject_OrganizationName_When_OrganizationWas_Empty() {
-        // given
-        versionInfo.companyName = null;
-        versionInfo.trademarks = null;
-
-        // when
-        versionInfo.tryFillOutByDefaults(project, outfile);
-
-        // then
-        assertNull(versionInfo.companyName);
-        assertNull(versionInfo.trademarks);
-    }
-
-    @Test
     public void should_Not_FillOutByDefaults_From_OrganizationName_When_VersionInfoPropsWere_Filled() {
         // given
         String organizationName = "Example OSS";
@@ -219,26 +213,6 @@ public class VersionInfoTest {
         // then
         assertEquals(organizationName, versionInfo.companyName);
         assertEquals(organizationName, versionInfo.trademarks);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void should_Not_FillOutByDefaults_SimpleValues_From_MavenProject_When_ProjectPropsWere_Empty() {
-        // given
-        doReturn(null).when(project).getVersion();
-        versionInfo.txtFileVersion = null;
-        versionInfo.txtProductVersion = null;
-
-        doReturn(null).when(project).getName();
-        versionInfo.productName = null;
-
-        doReturn(null).when(project).getArtifactId();
-        versionInfo.internalName = null;
-
-        doReturn(null).when(project).getDescription();
-        versionInfo.fileDescription = null;
-
-        // expect throws
-        versionInfo.tryFillOutByDefaults(project, outfile);
     }
 
     @Test
@@ -329,6 +303,56 @@ public class VersionInfoTest {
 
         // then
         assertEquals(outfileName, versionInfo.originalFilename);
+    }
+
+    @Test
+    public void shouldLogWarningsAboutDummyValues() {
+        // given
+        ArgumentCaptor<String> logMessageCaptor = ArgumentCaptor.forClass(String.class);
+        List<String> missingParamNames = Arrays.asList(
+                "project.version",
+                "project.name",
+                "project.artifactId",
+                "project.description",
+                "project.inceptionYear",
+                "project.organization.name",
+                "outfile"
+        );
+
+        // when
+        versionInfo.tryFillOutByDefaults(project, outfile);
+
+        // then
+        verify(log, times(missingParamNames.size())).warn(logMessageCaptor.capture());
+        List<String> logMessages = logMessageCaptor.getAllValues();
+
+
+        missingParamNames.forEach(missingParamName -> {
+            assertTrue(logMessages.stream().anyMatch(message -> message.contains(missingParamName)));
+        });
+    }
+
+    @Test
+    public void shouldFillOut_ByDummyValues_When_OriginalValues_Empty_And_ProjectParams_Empty() {
+        // given
+        VersionInfo emptyValuesVersionInfo = new VersionInfo();
+        emptyValuesVersionInfo.setLog(log);
+
+        // when
+        emptyValuesVersionInfo.tryFillOutByDefaults(project, outfile);
+
+        // then
+        assertEquals("1.0.0.0", emptyValuesVersionInfo.fileVersion);
+        assertEquals("1.0.0", emptyValuesVersionInfo.txtFileVersion);
+        assertEquals("A Java project.", emptyValuesVersionInfo.fileDescription);
+        assertEquals("Copyright © 2020-2023 Default organization. All rights reserved.", emptyValuesVersionInfo.copyright);
+        assertEquals("1.0.0.0", emptyValuesVersionInfo.productVersion);
+        assertEquals("1.0.0", emptyValuesVersionInfo.txtProductVersion);
+        assertEquals("Java Project", emptyValuesVersionInfo.productName);
+        assertEquals("Default organization", emptyValuesVersionInfo.companyName);
+        assertEquals("java-project", emptyValuesVersionInfo.internalName);
+        assertEquals("Default organization", emptyValuesVersionInfo.trademarks);
+        assertEquals("app.exe", emptyValuesVersionInfo.originalFilename);
     }
 
     @Test

--- a/src/test/java/com/akathist/maven/plugins/launch4j/generators/CopyrightGeneratorTest.java
+++ b/src/test/java/com/akathist/maven/plugins/launch4j/generators/CopyrightGeneratorTest.java
@@ -1,6 +1,5 @@
 package com.akathist.maven.plugins.launch4j.generators;
 
-import org.apache.maven.model.Organization;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -51,11 +50,8 @@ public class CopyrightGeneratorTest {
         // given
         final String organizationName = "SoftwareMill";
 
-        Organization projectOrganization = new Organization();
-        projectOrganization.setName(organizationName);
-
         // when
-        final String copyright = CopyrightGenerator.generate(null, projectOrganization);
+        final String copyright = CopyrightGenerator.generate(null, organizationName);
 
         // then
         String expected = concatAndWrapWithCopyright(
@@ -70,11 +66,8 @@ public class CopyrightGeneratorTest {
         final String projectInceptionYear = "2020";
         final String organizationName = "Orphan OSS";
 
-        Organization projectOrganization = new Organization();
-        projectOrganization.setName(organizationName);
-
         // when
-        final String copyright = CopyrightGenerator.generate(projectInceptionYear, projectOrganization);
+        final String copyright = CopyrightGenerator.generate(projectInceptionYear, organizationName);
 
         // then
         String expected = concatAndWrapWithCopyright(


### PR DESCRIPTION
## Version notes 2.3.1
- logs only warnings instead of throwing exception, when cannot fulfill default values for `<VersionInfo>`
  (no configuration data required by the formula), see Issue [#213](../issues/213). All missing fields will be fulfilled by dummy values like on the list:
  ```yaml
  project.version: 1.0.0
  project.organization.name: Default organization
  project.inceptionYear: 2020
  project.name: Java Project
  project.artifactId: java-project
  project.description: A Java project.
  outfile: app.exe
  ```
  
Closes #213 