### PR TITLE
Defaults for jre.path and headerType

### DIFF
--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -135,7 +135,7 @@ public class Launch4jMojo extends AbstractMojo {
      * in order to avoid opening a DOS window.
      * Choosing gui also enables other options like taskbar icon and a splash screen.
      */
-    @Parameter
+    @Parameter(defaultValue = "console", required = true)
     private String headerType;
 
     /**
@@ -349,7 +349,6 @@ public class Launch4jMojo extends AbstractMojo {
             return;
         }
 	
-        fillSensibleHeaderTypeDefaults();
         fillSensibleJreDefaults();
 
         if (!disableVersionInfoDefaults) {
@@ -493,21 +492,6 @@ public class Launch4jMojo extends AbstractMojo {
         }
     }
     
-    private void fillSensibleHeaderTypeDefaults() throws MojoExecutionException {
-        if (headerType == null) {
-            if (classPath != null && classPath.mainClass != null) {
-                if (classPath.mainClass.toLowerCase().contains("gui")) {
-                    getLog().warn("headerType not set, defaulting to \"gui\" because the main class is named " + classPath.mainClass);
-                    headerType = "gui";
-                    return;
-                }
-            }
-
-            getLog().warn("headerType not set, defaulting to \"console\"");
-            headerType = "console";
-        }
-    }
-
     private void fillSensibleJreDefaults() throws MojoExecutionException {
         if (jre == null) {
             jre = new Jre();

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -350,6 +350,7 @@ public class Launch4jMojo extends AbstractMojo {
         }
 	
         fillSensibleHeaderTypeDefaults();
+        fillSensibleJreDefaults();
 
         if (!disableVersionInfoDefaults) {
             try {
@@ -504,6 +505,18 @@ public class Launch4jMojo extends AbstractMojo {
 
             getLog().warn("headerType not set, defaulting to \"console\"");
             headerType = "console";
+        }
+    }
+
+    private void fillSensibleJreDefaults() throws MojoExecutionException {
+        if (jre == null) {
+            jre = new Jre();
+        }
+
+        if (jre.path == null) {
+            String pathDef = "%JAVA_HOME%;%PATH%";
+            getLog().warn("jre.path not set, defaulting to \"" + pathDef + "\"");
+            jre.path = pathDef;
         }
     }
 

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -348,6 +348,8 @@ public class Launch4jMojo extends AbstractMojo {
             getLog().debug("Skipping execution of the plugin");
             return;
         }
+	
+        fillSensibleHeaderTypeDefaults();
 
         if (!disableVersionInfoDefaults) {
             try {
@@ -487,6 +489,21 @@ public class Launch4jMojo extends AbstractMojo {
             } catch (ConfigPersisterException e) {
                 throw new MojoExecutionException("Cannot save config into a XML file", e);
             }
+        }
+    }
+    
+    private void fillSensibleHeaderTypeDefaults() throws MojoExecutionException {
+        if (headerType == null) {
+            if (classPath != null && classPath.mainClass != null) {
+                if (classPath.mainClass.toLowerCase().contains("gui")) {
+                    getLog().warn("headerType not set, defaulting to \"gui\" because the main class is named " + classPath.mainClass);
+                    headerType = "gui";
+                    return;
+                }
+            }
+
+            getLog().warn("headerType not set, defaulting to \"console\"");
+            headerType = "console";
         }
     }
 


### PR DESCRIPTION
Path defaults to %JAVA_HOME%;%PATH% which is probably what most users want

Header type defaults to console, unless the main class has "gui" in full name, then to gui.

Closes #338 