### PR TITLE
A small stopgap regarding extensibility/inheritance

### DIFF
--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -72,11 +72,11 @@ import java.util.stream.Collectors;
 )
 public class Launch4jMojo extends AbstractMojo {
 
-    // intentionally non-static non-final, so they can be changed
-    // via reflection if someone absolutely positively needs to
-    private String LAUNCH4J_ARTIFACT_ID = "launch4j";
+    @Parameter(defaultValue = "launch4j", required = true)
+    private String launch4jArtifactId;
 
-    private String LAUNCH4J_GROUP_ID = "net.sf.launch4j";
+    @Parameter(defaultValue = "net.sf.launch4j", required = true)
+    private String launch4jGroupId;
 
     /**
      * Maven Session.
@@ -698,7 +698,7 @@ public class Launch4jMojo extends AbstractMojo {
             throw new MojoExecutionException("Sorry, Launch4j doesn't support the '" + os + "' OS.");
         }
 
-        Artifact artifact = new DefaultArtifact(LAUNCH4J_GROUP_ID, LAUNCH4J_ARTIFACT_ID, "workdir-" + plat, "jar", getLaunch4jVersion());
+        Artifact artifact = new DefaultArtifact(launch4jGroupId, launch4jArtifactId, "workdir-" + plat, "jar", getLaunch4jVersion());
         try {
             ArtifactRequest request = new ArtifactRequest(artifact, repositories, null);
 
@@ -818,8 +818,8 @@ public class Launch4jMojo extends AbstractMojo {
         ).collect(Collectors.toSet());
 
         for (Artifact artifact : pluginArtifacts) {
-            if (LAUNCH4J_GROUP_ID.equals(artifact.getGroupId()) &&
-                    LAUNCH4J_ARTIFACT_ID.equals(artifact.getArtifactId())
+            if (launch4jGroupId.equals(artifact.getGroupId()) &&
+                    launch4jArtifactId.equals(artifact.getArtifactId())
                     && "core".equals(artifact.getClassifier())) {
 
                 version = artifact.getVersion();

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -72,9 +72,11 @@ import java.util.stream.Collectors;
 )
 public class Launch4jMojo extends AbstractMojo {
 
-    private static final String LAUNCH4J_ARTIFACT_ID = "launch4j";
+    // intentionally non-static non-final, so they can be changed
+    // via reflection if someone absolutely positively needs to
+    private String LAUNCH4J_ARTIFACT_ID = "launch4j";
 
-    private static final String LAUNCH4J_GROUP_ID = "net.sf.launch4j";
+    private String LAUNCH4J_GROUP_ID = "net.sf.launch4j";
 
     /**
      * Maven Session.


### PR DESCRIPTION
Could you please change the variables near the top, the ones specifying launch4j group/artifact,
so they're non-static non-final?

Rationale: it doesn't matter in normal use, but it hardcodes the plugin to specific launch4j
artifact. With the change it would be possible to extend the plugin declaring it as dependency,
instead of having to fork it as it is now. Plenty of things can be hacked into via reflection,
but not static final fields, there were some hacks but they aren't working in recent versions
of Java.

Right now if you change the dependency to a fork of launch4j, everything just stops working.
With this it would be enough to, at minimum, change these fields in constructor via reflection,
and in an extending class, with no further changes required to the plugin itself, and with a very
high chance it will work with the future versions of the plugin (with no guarantees obviously,
since they're still private so not part of the api).

I have some other more, no pun intended, extensive ideas regarding that subject, but this is the
minimum so it can be used that way via dependency and inheritance instead of full forking.