### PR TITLE
Option to skip if Graal already made exe

### DIFF
--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -343,6 +343,13 @@ public class Launch4jMojo extends AbstractMojo {
     @Parameter(defaultValue = "false")
     private boolean skip = false;
 
+    /**
+     * If set to true, make best effort to skip execution if other plugins are
+     * generating native image / exe file
+     */
+    @Parameter(defaultValue = "false")
+    private boolean skipIfNativeImage = false;
+
     private File getJar() {
         return new File(jar);
     }
@@ -363,6 +370,10 @@ public class Launch4jMojo extends AbstractMojo {
             getLog().debug("Skipping execution of the plugin");
             return;
         }
+	
+	if (this.skipIfNativeImage()) {
+	    getLog().debug("Parameter 'skipIfNativeImage' not implemented yet.");
+	}
 	
         processRequireAdminRights();
 
@@ -931,6 +942,14 @@ public class Launch4jMojo extends AbstractMojo {
         getLog().debug("skip = " + this.skip);
         getLog().debug("skipLaunch4j = " + System.getProperty("skipLaunch4j"));
         return skip || System.getProperty("skipLaunch4j") != null;
+    }
+    
+    private boolean skipIfNativeImage() {
+        getLog().debug("skipIfNativeImage = " + this.skipIfNativeImage);
+	String sysProp = System.getProperty("skipLaunch4jIfNativeImage");
+        getLog().debug("skipLaunch4jIfNativeImage = " + sysProp);
+	
+        return skipIfNativeImage || (sysProp != null && !sysProp.equalsIgnoreCase("false"));
     }
 
     @Override

--- a/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/Launch4jMojo.java
@@ -940,8 +940,11 @@ public class Launch4jMojo extends AbstractMojo {
      */
     private boolean skipExecution() {
         getLog().debug("skip = " + this.skip);
-        getLog().debug("skipLaunch4j = " + System.getProperty("skipLaunch4j"));
-        return skip || System.getProperty("skipLaunch4j") != null;
+	String sysProp = System.getProperty("skipLaunch4j");
+        getLog().debug("skipLaunch4j = " + sysProp);
+
+	return skip || (sysProp != null && !sysProp.equalsIgnoreCase("false"));
+	
     }
     
     private boolean skipIfNativeImage() {


### PR DESCRIPTION
Rationale:
As it is now, if you create a simple Micronaut app and just add Launch4j with minimal/typical configuration, it will create the exe as normal with a normal build, but also during a packaging=native-image build, overwriting the one made by Graal.

I made a quick fix that adds skipIfNativeImage param that does just that, tries to detect if Graal was already executed during the current build. It could use some more testing, but it works with the projects I'm working on right now