### PR TITLE
✨ feat: Updating regex to fully support "semver"

### DIFF
--- a/src/main/java/com/akathist/maven/plugins/launch4j/generators/Launch4jFileVersionGenerator.java
+++ b/src/main/java/com/akathist/maven/plugins/launch4j/generators/Launch4jFileVersionGenerator.java
@@ -2,11 +2,12 @@ package com.akathist.maven.plugins.launch4j.generators;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Launch4jFileVersionGenerator {
     private static final int REQUIRED_NESTED_VERSION_LEVELS = 4;
-    private static final String SIMPLE_PROJECT_VERSION_REGEX = "^((\\d(\\.)?)*\\d+)(-\\w+)?$";
+    private static final String SIMPLE_PROJECT_VERSION_REGEX = "^((\\d(\\.)?)*\\d+)(-\\w+)?(?:-(?<prerelease>[\\w.-]+))?(?:\\+(?<build>[\\w.-]+))?$";
     private static final Pattern simpleProjectVersionPattern = Pattern.compile(
             SIMPLE_PROJECT_VERSION_REGEX, Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE
     );
@@ -40,12 +41,13 @@ public class Launch4jFileVersionGenerator {
     }
 
     private static String removeTextFlags(String version) {
-        if(version.contains("-")) {
-            String[] parts = version.split("-");
-            return parts[0];
+        Pattern pattern = Pattern.compile("[-+]");
+        Matcher matcher = pattern.matcher(version);
+        if (matcher.find()) {
+            return version.substring(0, matcher.start());
+        } else {
+            return version;
         }
-
-        return version;
     }
 
     private static String cutOffTooManyNestedLevels(String versionLevels) {

--- a/src/test/java/com/akathist/maven/plugins/launch4j/generators/Launch4jFileVersionGeneratorTest.java
+++ b/src/test/java/com/akathist/maven/plugins/launch4j/generators/Launch4jFileVersionGeneratorTest.java
@@ -59,6 +59,13 @@ public class Launch4jFileVersionGeneratorTest {
         "1.2.1-alpha, 1.2.1.0",
         "1.2.3.4-beta, 1.2.3.4",
         "0.0.1-snapshot, 0.0.1.0",
+        "1.2.3.4-alpha+001, 1.2.3.4",
+        "1.2.3-alpha+001, 1.2.3.0",
+        "1.2.3.4-alpha+001, 1.2.3.4",
+        "1.2.3+20130313144700, 1.2.3.0",
+        "1.2.3.4+20130313144700, 1.2.3.4",
+        "1.2.3-beta+exp.sha.5114f85, 1.2.3.0",
+        "1.2.3.4-beta+exp.sha.5114f85, 1.2.3.4",
     })
     public void shouldCutOffTextFlags(String projectVersion, String expected) {
         // when


### PR DESCRIPTION
In the projects I use in my work, we use beta versions in semver format, such as:
- 1.2.3.4-beta+exp.sha.5114f85
- 1.2.3-alpha+001

And when I updated to the newer versions of the project (>2.3.0) errors started to occur informing me that it was an invalid version.

I am proposing to also support this format in compilations.